### PR TITLE
Add petrelharp as recipe maintainer

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @jeromekelleher
+* @jeromekelleher @petrelharp

--- a/README.md
+++ b/README.md
@@ -144,4 +144,5 @@ Feedstock Maintainers
 =====================
 
 * [@jeromekelleher](https://github.com/jeromekelleher/)
+* [@petrelharp](https://github.com/petrelharp/)
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -42,3 +42,4 @@ about:
 extra:
   recipe-maintainers:
     - jeromekelleher
+    - petrelharp


### PR DESCRIPTION
## Summary
- Add petrelharp as a recipe maintainer for tstrait-feedstock

This PR adds petrelharp to the list of recipe maintainers for the tstrait conda-forge package.